### PR TITLE
Update IRConstants.fs

### DIFF
--- a/CWTools/Common/IRConstants.fs
+++ b/CWTools/Common/IRConstants.fs
@@ -127,7 +127,7 @@ module IRConstants =
             member this.Tag = this.tag
 
     let categoryScopeList = [
-        ModifierCategory.Character, [Scope.Character];
+        ModifierCategory.Character, [Scope.Character; Scope.Country];
         ModifierCategory.Unit, [Scope.Unit; Scope.Country];
         ModifierCategory.Province, [Scope.Province; Scope.Country];
         ModifierCategory.Country, [Scope.Country];


### PR DESCRIPTION
Character modifiers can also be country-scope (either applied to every character in the country or to the ruler; but I think it's the former).